### PR TITLE
usb_touchpad: Fail if retry counter reaches three

### DIFF
--- a/usb_touchpad.c
+++ b/usb_touchpad.c
@@ -119,7 +119,7 @@ int write_tp_fw(const unsigned char *fw, int fw_length)
         usleep(500*1000);
     }
 
-    if (try == 20) {
+    if (try >= 3) {
         printf(">>> Failed to open in touchpad mode\n");
         goto finish;
     }


### PR DESCRIPTION
Previously the retry counter was checked against 20 which it could
not reach, even if the touchpad is not enumerating.
This resulted in a segfault without a concise error message.